### PR TITLE
Document the current ONNX support status

### DIFF
--- a/docs/issues/issue-5-onnx-support.md
+++ b/docs/issues/issue-5-onnx-support.md
@@ -1,0 +1,22 @@
+# Issue #5 — ONNX support status
+
+## Summary
+The current repository does not ship an ONNX export or ONNX Runtime inference path.
+
+## Current repository signals
+- No ONNX or ONNX Runtime dependency is declared in the root `pyproject.toml`.
+- No export script based on `torch.onnx.export(...)` is present in the repository.
+- The repository currently focuses on PyTorch inference plus an Apple-specific MLX port.
+
+## What is missing for ONNX inference support
+A credible ONNX path would need at least:
+1. an export script for the relevant model components
+2. shape / dynamic-axis decisions for text + acoustic generation
+3. runtime validation against ONNX Runtime or another ONNX backend
+4. clear guidance for unsupported operators or model components that do not export cleanly
+
+## Safe contribution starting point
+A minimal first step would be a prototype export investigation for a single component, with an operator compatibility report and a small parity check against PyTorch outputs.
+
+## Important limitation
+This note should not be read as claiming ONNX support today. It only records that the repository does not currently expose that path and explains what would need to be added.


### PR DESCRIPTION
## Summary
    Addresses #5 by adding a narrow repository note for the current public status of this request.

    ## Problem statement
    Issue #5 asks for ONNX support, but the repository does not currently tell readers whether ONNX export exists, what is missing, or where a contribution would need to start.

    ## Root cause
    There is no ONNX export script, no ONNX Runtime dependency, and no documented operator/export path in the current public repo.

    ## What changed
    - added `docs/issues/issue-5-onnx-support.md`
- documented the absence of a current ONNX path in the repo
- outlined the minimum work needed for a credible ONNX implementation

    ## Why this design
    A status note is safer than implying feature support that the repository does not yet implement.

    ## Overlap assessment
    Net-new relative to current open PRs; references issue #5 only.

    ## Validation
    - `git diff --check --cached`

    ## Risk / compatibility
    Low risk. Documentation-only and explicit about non-support.

    ## Files changed
    - `docs/issues/issue-5-onnx-support.md`
