### PR TITLE
Document the current Turkish training status

### DIFF
--- a/docs/issues/issue-3-turkish-training.md
+++ b/docs/issues/issue-3-turkish-training.md
@@ -1,0 +1,24 @@
+# Issue #3 — Turkish training status
+
+## Summary
+The repository currently documents multilingual generation for a fixed set of languages, but it does not publish a supported training workflow for adding Turkish.
+
+## Current repository state
+- The README documents multilingual generation with language-specific aligners.
+- The listed supported languages are `ar`, `ch`, `de`, `es`, `fr`, `it`, `ja`, `pl`, and `pt`.
+- Turkish is not listed in that supported-language set.
+- The repository does not currently ship public training or fine-tuning scripts for adding new languages.
+
+## What this means today
+- The public repo does not currently document Turkish generation support.
+- The public repo also does not currently expose a supported training path for adding Turkish.
+
+## What would be required
+Supporting Turkish through the public repository would likely need:
+1. released training / fine-tuning code
+2. a Turkish alignment strategy
+3. data preparation guidance for Turkish text/audio pairs
+4. validation for generation quality and alignment quality in Turkish
+
+## Current safe answer
+Based on the repository as it exists today, Turkish training support is not yet documented in the public release.


### PR DESCRIPTION
## Summary
    Addresses #3 by adding a narrow repository note for the current public status of this request.

    ## Problem statement
    Issue #3 asks about Turkish training support, but the repo only documents multilingual generation for a fixed language set and does not currently publish training scripts for adding Turkish.

    ## Root cause
    Turkish is not in the README's listed supported languages, and the public repo does not yet expose training/fine-tuning code for adding new languages.

    ## What changed
    - added `docs/issues/issue-3-turkish-training.md`
- documented the languages currently listed in the README
- documented what is still missing for Turkish training support

    ## Why this design
    A repository note is the most honest minimal PR because it clarifies the current public state without claiming unsupported language-training coverage.

    ## Overlap assessment
    Net-new relative to current open PRs; references issue #3 only.

    ## Validation
    - `git diff --check --cached`

    ## Risk / compatibility
    Low risk. Documentation-only and fact-limited to the current public repo.

    ## Files changed
    - `docs/issues/issue-3-turkish-training.md`
