### PR TITLE
Document the current training and vLLM guidance status

### DIFF
--- a/docs/issues/issue-2-training-and-vllm.md
+++ b/docs/issues/issue-2-training-and-vllm.md
@@ -1,0 +1,21 @@
+# Issue #2 — Training script and serving guidance status
+
+## Summary
+The current public repository is focused on inference and model conversion. It does not yet include the minimal training reference requested in issue #2.
+
+## Current repository state
+- The repository includes inference examples and conversion scripts.
+- Public training / fine-tuning scripts are not currently present.
+- In the issue thread, one commenter suggests that `vllm-omni` is the most relevant avenue for multimodal serving.
+- In the same thread, a collaborator states that the team plans to release a minimal version of the training code in the coming weeks.
+
+## What this means today
+- A public minimal training reference is not yet available in the repository.
+- vLLM integration guidance is not yet documented as a first-class supported serving path in the repo itself.
+
+## Safe guidance captured from the issue thread
+- For multimodal serving exploration, `vllm-omni` is the most specific direction mentioned in the thread.
+- For training, the public status is: planned minimal training-code release, but not yet shipped here.
+
+## Why this note exists
+Issue #2 asks for status and guidance. This note records the current public answer without overstating repository capabilities.


### PR DESCRIPTION
## Summary
    Addresses #2 by adding a narrow repository note for the current public status of this request.

    ## Problem statement
    Issue #2 asks for a minimal training reference and vLLM guidance, but the public repo does not currently preserve the issue-thread status in repository documentation.

    ## Root cause
    The repository includes inference and conversion scripts, but not public training scripts; the only published guidance currently lives in the issue thread comments.

    ## What changed
    - added `docs/issues/issue-2-training-and-vllm.md`
- recorded that training code is planned but not yet shipped publicly
- captured the thread guidance pointing to `vllm-omni` for multimodal serving exploration

    ## Why this design
    This keeps the PR narrow, truthful, and directly tied to the published issue-thread guidance.

    ## Overlap assessment
    Net-new relative to current open PRs; references issue #2 only.

    ## Validation
    - `git diff --check --cached`

    ## Risk / compatibility
    Low risk. Documentation-only and explicit about the current non-availability of training code.

    ## Files changed
    - `docs/issues/issue-2-training-and-vllm.md`
