### PR TITLE
Remove unsupported inference options

### DIFF
--- a/apple/mlx_tada/config.py
+++ b/apple/mlx_tada/config.py
@@ -83,10 +83,6 @@ class InferenceOptions:
     noise_temperature: float = 0.9
     num_flow_matching_steps: int = 20
     time_schedule: Literal["uniform", "cosine", "logsnr"] = "logsnr"
-    num_acoustic_candidates: int = 1
-    scorer: Literal["spkr_verification", "likelihood", "duration_median"] = "likelihood"
-    negative_condition_source: Literal["negative_step_output", "prompt", "zero"] = "negative_step_output"
-    text_only_logit_scale: float = 0.0
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Remove 4 `InferenceOptions` fields that were defined but never wired up in the MLX generation pipeline: `num_acoustic_candidates`, `scorer`, `negative_condition_source`, and `text_only_logit_scale`
- The 10 options that are actually used (text sampling params, CFG scales, flow matching, etc.) remain unchanged

## Test plan
- [x] Verified long generation (42.96s output) works with 4-bit quantization after removal
- [ ] Run existing tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)