### PR TITLE
Use tuples for mutable config defaults (fixes import on transformers 5)

### DIFF
--- a/tada/modules/decoder.py
+++ b/tada/modules/decoder.py
@@ -171,7 +171,7 @@ class DecoderConfig(PretrainedConfig):
     attn_dropout: float = 0.1
     use_flash_attn: bool = True
     wav_decoder_channels: int = 1536
-    strides: list[int] = [4, 4, 5, 6]
+    strides: tuple[int, ...] = (4, 4, 5, 6)
     block_attention: Literal["none", "v1", "v2"] = "v2"
 
 

--- a/tada/modules/encoder.py
+++ b/tada/modules/encoder.py
@@ -556,7 +556,7 @@ class LocalAttentionEncoder(torch.nn.Module):
 class EncoderConfig(PretrainedConfig):
     hidden_dim: int = 1024
     embed_dim: int = 512
-    strides: list[int] = [6, 5, 4, 4]
+    strides: tuple[int, ...] = (6, 5, 4, 4)
     num_attn_layers: int = 6
     num_attn_heads: int = 8
     attn_dim_feedforward: int = 4096


### PR DESCRIPTION
The `strides` fields on `EncoderConfig` and `DecoderConfig` are declared as bare list defaults:

```python
strides: list[int] = [6, 5, 4, 4]   # encoder.py
strides: list[int] = [4, 4, 5, 6]   # decoder.py
```

On transformers 4 this is harmless — config classes are plain classes and the list is a shared class attribute. On transformers 5, `PretrainedConfig.__init_subclass__` turns every subclass into a dataclass, and dataclasses reject mutable defaults:

```
ValueError: mutable default <class 'list'> for field strides is not allowed: use default_factory
```

`import tada.modules` fails outright, so the package is unusable on transformers 5.

## Why tuples rather than `field(default_factory=...)`

`default_factory` would work on 5 but break on 4, where the class isn't a dataclass — it would leave a `Field` object as the attribute value. Tuples need no version guard.

Both fields are only ever iterated, so an immutable sequence is a drop-in:

- `WavEncoder.__init__` — `for stride in strides`
- `Decoder.__init__` — passed to DAC's decoder as `rates`, which does `for i, stride in enumerate(rates)`

It also removes the shared-mutable-state hazard that made dataclasses reject the pattern to begin with.

## Verification

```
transformers 4.57.6  ->  EncoderConfig().strides == (6, 5, 4, 4)
transformers 5.15.0  ->  EncoderConfig().strides == (6, 5, 4, 4)
```

The JSON round-trip is unaffected (`to_json_string` → `from_dict` yields the same values), and the published `HumeAI/tada-codec` configs don't override `strides`, so they keep loading from these defaults.

End-to-end synthesis on transformers 4.57.6 (Apple Silicon / MPS, `tada-3b-ml` with a cloned reference voice) is unchanged after the patch — 10 consecutive pt-BR turns, all within 0.89–1.09× of the expected duration.

## Not the whole story

This is scoped to the config defaults. Loading on transformers 5 then trips on `all_tied_weights_keys`, which replaced `_tied_weights_keys` and is now expected by `_finalize_model_loading`. Happy to open a follow-up PR for that if it's useful — I kept this one to a single self-contained issue.